### PR TITLE
multi interface support

### DIFF
--- a/aiozeroconf/__main__.py
+++ b/aiozeroconf/__main__.py
@@ -33,13 +33,15 @@ from aiozeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
 
 
 def on_service_state_change(zc, service_type, name, state_change):
-    print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
-
     if state_change is ServiceStateChange.Added:
-        asyncio.ensure_future(on_service_state_change_process(zc,service_type,name))
+        asyncio.ensure_future(on_service_state_change_process(zc, service_type, name))
+    else:
+        print("Service %s of type %s state changed: %s" % (name, service_type, state_change))
 
-async def on_service_state_change_process(zc,service_type, name):
+
+async def on_service_state_change_process(zc, service_type, name):
     info = await zc.get_service_info(service_type, name)
+    print("Service %s of type %s state changed: %s" % (name, service_type, ServiceStateChange.Added))
     if info:
         print("  Address: %s:%d" % (socket.inet_ntoa(info.address), info.port))
         print("  Weight: %d, priority: %d" % (info.weight, info.priority))
@@ -54,19 +56,19 @@ async def on_service_state_change_process(zc,service_type, name):
         print("  No info")
     print('\n')
 
+
 async def do_close(zc):
     await zc.close()
 
 
-
 parser = argparse.ArgumentParser(description="Track and interact with Lifx light bulbs.")
-parser.add_argument('-i', "--iface",  default="",
+parser.add_argument('-i', "--iface", default="",
                     help="Name of the inteface to use.")
 parser.add_argument('-p', "--protocol", choices=['ipv4', 'ipv6', 'both'], default="ipv4",
                     help="What IP protocol to use.")
 parser.add_argument("-s", "--service", default="_http._tcp.local.",
                     help="The service to browse.")
-parser.add_argument("-d","--debug", action='store_true', default=False,
+parser.add_argument("-d", "--debug", action='store_true', default=False,
                     help="Set debug mode.")
 try:
     opts = parser.parse_args()
@@ -74,12 +76,11 @@ except Exception as e:
     parser.error("Error: " + str(e))
 
 if opts.protocol == "ipv4":
-    proto=[netifaces.AF_INET]
+    proto = [netifaces.AF_INET]
 elif opts.protocol == "ipv6":
-    proto=[netifaces.AF_INET6]
+    proto = [netifaces.AF_INET6]
 else:
-    proto=[netifaces.AF_INET,netifaces.AF_INET6]
-
+    proto = [netifaces.AF_INET, netifaces.AF_INET6]
 
 loop = asyncio.get_event_loop()
 logging.basicConfig(level=logging.CRITICAL)
@@ -87,7 +88,7 @@ if opts.debug:
     logging.getLogger('zeroconf').setLevel(logging.DEBUG)
     loop.set_debug(True)
 
-zc=Zeroconf(loop,proto,iface=opts.iface)
+zc = Zeroconf(loop, proto, iface=opts.iface)
 print("\nBrowsing services, press Ctrl-C to exit...\n")
 browser = ServiceBrowser(zc, opts.service, handlers=[on_service_state_change])
 try:

--- a/aiozeroconf/__main__.py
+++ b/aiozeroconf/__main__.py
@@ -43,7 +43,10 @@ async def on_service_state_change_process(zc, service_type, name):
     info = await zc.get_service_info(service_type, name)
     print("Service %s of type %s state changed: %s" % (name, service_type, ServiceStateChange.Added))
     if info:
-        print("  Address: %s:%d" % (socket.inet_ntoa(info.address), info.port))
+        if info.address:
+            print("  IPv4 Address: %s:%d" % (socket.inet_ntoa(info.address), info.port))
+        if info.address6:
+            print("  IPv6 Address: %s:%d" % (socket.inet_ntop(netifaces.AF_INET6, info.address6), info.port))
         print("  Weight: %d, priority: %d" % (info.weight, info.priority))
         print("  Server: %s" % (info.server,))
         if info.properties:

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -1111,7 +1111,7 @@ class MCListener(asyncio.Protocol, QuietLogger):
             socket.sendto(data, destination)
 
 
-class Reaper():
+class Reaper(object):
     """A Reaper is used by this module to remove cache entries that
     have expired."""
 
@@ -1129,7 +1129,7 @@ class Reaper():
                     self.zc.cache.remove(record)
 
 
-class ServiceBrowser():
+class ServiceBrowser(object):
     """Used to browse for a service of a specific type.
 
     The listener object will have its add_service() and

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -1375,7 +1375,7 @@ class ServiceInfo(object):
             if cached:
                 self.update_record(zc, now, cached)
 
-        if None not in (self.server, self.address, self.text):
+        if None not in (self.server, self.address, self.text) or timeout == 0:
             return True
 
         try:

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -62,7 +62,7 @@ __license__ = 'GPL'
 __all__ = [
     "__version__",
     "Zeroconf", "ServiceInfo", "ServiceBrowser", "ZeroconfServiceTypes",
-    "Error", "InterfaceChoice", "ServiceStateChange",
+    "MDNSError", "InterfaceChoice", "ServiceStateChange",
 ]
 
 log = logging.getLogger(__name__)
@@ -296,19 +296,19 @@ def service_type_name(type_):
 # Exceptions
 
 
-class Error(Exception):
+class MDNSError(Exception):
     pass
 
 
-class IncomingDecodeError(Error):
+class IncomingDecodeError(MDNSError):
     pass
 
 
-class NonUniqueNameException(Error):
+class NonUniqueNameException(MDNSError):
     pass
 
 
-class NamePartTooLongException(Error):
+class NamePartTooLongException(MDNSError):
     pass
 
 
@@ -316,7 +316,7 @@ class AbstractMethodException(Error):
     pass
 
 
-class BadTypeInNameException(Error):
+class BadTypeInNameException(MDNSError):
     pass
 
 

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -50,6 +50,7 @@ import struct
 import sys
 import asyncio
 import time
+from abc import abstractmethod
 from functools import reduce, partial
 
 import netifaces
@@ -312,10 +313,6 @@ class NamePartTooLongException(MDNSError):
     pass
 
 
-class AbstractMethodException(Error):
-    pass
-
-
 class BadTypeInNameException(MDNSError):
     pass
 
@@ -424,9 +421,9 @@ class DNSRecord(DNSEntry):
         self.ttl = ttl
         self.created = current_time_millis()
 
+    @abstractmethod
     def __eq__(self, other):
-        """Abstract method"""
-        raise AbstractMethodException
+        """All records must implement this"""
 
     def suppressed_by(self, msg):
         """Returns true if any answer in a message can suffice for the
@@ -464,9 +461,9 @@ class DNSRecord(DNSEntry):
         self.created = other.created
         self.ttl = other.ttl
 
+    @abstractmethod
     def write(self, out):
-        """Abstract method"""
-        raise AbstractMethodException
+        """Write data out"""
 
     def to_string(self, other):
         """String representation with additional information"""

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -59,13 +59,11 @@ __maintainer__ = 'François Wautier <francois@wautier.eu>'
 __version__ = '0.1.0'
 __license__ = 'GPL'
 
-
 __all__ = [
     "__version__",
     "Zeroconf", "ServiceInfo", "ServiceBrowser", "ZeroconfServiceTypes",
     "Error", "InterfaceChoice", "ServiceStateChange",
 ]
-
 
 log = logging.getLogger(__name__)
 log.addHandler(logging.NullHandler())
@@ -321,6 +319,7 @@ class AbstractMethodException(Error):
 class BadTypeInNameException(Error):
     pass
 
+
 # implementation classes
 
 
@@ -354,7 +353,6 @@ class QuietLogger(object):
 
 
 class DNSEntry(object):
-
     """A DNS entry"""
 
     def __init__(self, name, type_, class_):
@@ -402,7 +400,6 @@ class DNSEntry(object):
 
 
 class DNSQuestion(DNSEntry):
-
     """A DNS question entry"""
 
     def __init__(self, name, type_, class_):
@@ -420,7 +417,6 @@ class DNSQuestion(DNSEntry):
 
 
 class DNSRecord(DNSEntry):
-
     """A DNS record - like a DNS entry, but has a TTL"""
 
     def __init__(self, name, type_, class_, ttl):
@@ -480,7 +476,6 @@ class DNSRecord(DNSEntry):
 
 
 class DNSAddress(DNSRecord):
-
     """A DNS address record"""
 
     def __init__(self, name, type_, class_, ttl, address):
@@ -504,7 +499,6 @@ class DNSAddress(DNSRecord):
 
 
 class DNSHinfo(DNSRecord):
-
     """A DNS host information record"""
 
     def __init__(self, name, type_, class_, ttl, cpu, os):
@@ -534,7 +528,6 @@ class DNSHinfo(DNSRecord):
 
 
 class DNSPointer(DNSRecord):
-
     """A DNS pointer record"""
 
     def __init__(self, name, type_, class_, ttl, alias):
@@ -555,7 +548,6 @@ class DNSPointer(DNSRecord):
 
 
 class DNSText(DNSRecord):
-
     """A DNS text record"""
 
     def __init__(self, name, type_, class_, ttl, text):
@@ -580,7 +572,6 @@ class DNSText(DNSRecord):
 
 
 class DNSService(DNSRecord):
-
     """A DNS service record"""
 
     def __init__(self, name, type_, class_, ttl, priority, weight, port, server):
@@ -611,7 +602,6 @@ class DNSService(DNSRecord):
 
 
 class DNSIncoming(QuietLogger):
-
     """Object representation of an incoming DNS packet"""
 
     def __init__(self, data):
@@ -766,7 +756,6 @@ class DNSIncoming(QuietLogger):
 
 
 class DNSOutgoing(object):
-
     """Object representation of an outgoing packet"""
 
     def __init__(self, flags, multicast=True):
@@ -1020,7 +1009,6 @@ class DNSOutgoing(object):
 
 
 class DNSCache(object):
-
     """A cache of DNS entries"""
 
     def __init__(self):
@@ -1080,14 +1068,12 @@ class DNSCache(object):
             return reduce(lambda a, b: a + b, values)
 
 
-
-class MCListener(asyncio.Protocol,QuietLogger):
-
+class MCListener(asyncio.Protocol, QuietLogger):
     """A MCListener is used by this module to listen on the multicast
     group to which DNS messages are sent, allowing the implementation
     to cache information as it arrives."""
 
-    def __init__(self, zc,future):
+    def __init__(self, zc, future):
         asyncio.Protocol.__init__(self)
         self.zc = zc
         self.data = None
@@ -1095,15 +1081,15 @@ class MCListener(asyncio.Protocol,QuietLogger):
 
     def connection_made(self, transport):
         self.transport = transport
-        self.future.set_result((transport,self))
+        self.future.set_result((transport, self))
 
     def datagram_received(self, data, addrs):
         try:
-            assert len(addrs) in [2,4], "What network protocol is that?"
+            assert len(addrs) in [2, 4], "What network protocol is that?"
             if len(addrs) == 2:
                 addr, port = addrs
             else:
-                addr, port, flow, scope =  addrs
+                addr, port, flow, scope = addrs
         except Exception:
             self.log_exception_warning()
             return
@@ -1134,7 +1120,6 @@ class MCListener(asyncio.Protocol,QuietLogger):
 
 
 class Reaper():
-
     """A Reaper is used by this module to remove cache entries that
     have expired."""
 
@@ -1153,7 +1138,6 @@ class Reaper():
 
 
 class ServiceBrowser():
-
     """Used to browse for a service of a specific type.
 
     The listener object will have its add_service() and
@@ -1177,7 +1161,7 @@ class ServiceBrowser():
             listener = handlers
             handlers = None
 
-        if handlers and not isinstance(handlers,list):
+        if handlers and not isinstance(handlers, list):
             self.handlers = [handlers]
         else:
             self.handlers = handlers or []
@@ -1198,9 +1182,9 @@ class ServiceBrowser():
                 if not expired:
                     self.services[service_key] = record
                     if self.listener:
-                        self.listener.add_service(self.zc,self.type, record.alias)
+                        self.listener.add_service(self.zc, self.type, record.alias)
                     for hdlr in self.handlers:
-                        hdlr(self.zc,self.type, record.alias,ServiceStateChange.Added)
+                        hdlr(self.zc, self.type, record.alias, ServiceStateChange.Added)
 
             else:
                 if not expired:
@@ -1208,9 +1192,9 @@ class ServiceBrowser():
                 else:
                     del self.services[service_key]
                     if self.listener:
-                        self.listener.remove_service(self.zc,self.type, record.alias)
+                        self.listener.remove_service(self.zc, self.type, record.alias)
                     for hdlr in self.handlers:
-                        hdlr(self.zc,self.type, record.alias,ServiceStateChange.Removed)
+                        hdlr(self.zc, self.type, record.alias, ServiceStateChange.Removed)
                     return
 
             expires = record.get_expiration_time(75)
@@ -1228,7 +1212,7 @@ class ServiceBrowser():
         while True:
             now = current_time_millis()
             if self.next_time > now:
-                await asyncio.sleep(round((self.next_time - now)/1000.0,2))
+                await asyncio.sleep(round((self.next_time - now) / 1000.0, 2))
             if self.zc.done or self.done:
                 return
             now = current_time_millis()
@@ -1244,7 +1228,6 @@ class ServiceBrowser():
 
 
 class ServiceInfo(object):
-
     """Service information"""
 
     def __init__(self, type_, name, address=None, port=None, weight=0,
@@ -1421,7 +1404,7 @@ class ServiceInfo(object):
                     zc.send(out)
                     next_ = now + delay
                     delay *= 2
-                await asyncio.sleep((min(next_, last) - now)/1000.0)
+                await asyncio.sleep((min(next_, last) - now) / 1000.0)
                 now = current_time_millis()
         except:
             pass
@@ -1455,6 +1438,7 @@ class ZeroconfServiceTypes(object):
     """
     Return all of the advertised services on any local networks
     """
+
     def __init__(self):
         self.found_services = set()
 
@@ -1485,10 +1469,8 @@ class ZeroconfServiceTypes(object):
         return tuple(sorted(listener.found_services))
 
 
-
 def new_socket(address_family, iface=""):
-
-    assert address_family in [netifaces.AF_INET,netifaces.AF_INET6], 'Only IPv4 and IPv6 are supported'
+    assert address_family in [netifaces.AF_INET, netifaces.AF_INET6], 'Only IPv4 and IPv6 are supported'
     s = socket.socket(address_family, socket.SOCK_DGRAM)
     s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 
@@ -1517,11 +1499,11 @@ def new_socket(address_family, iface=""):
     interfaces = [iface] if iface else netifaces.interfaces()
 
     s.bind(('', _MDNS_PORT))
-    if address_family == netifaces.AF_INET: # IPv4
+    if address_family == netifaces.AF_INET:  # IPv4
         ttl = struct.pack('@i', 255)
         s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, ttl)
-        #loopv = struct.pack(b'B', 1)
-        #s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, loopv)
+        # loopv = struct.pack(b'B', 1)
+        # s.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_LOOP, loopv)
 
         addresses = []
         for interface in interfaces:
@@ -1597,17 +1579,16 @@ def get_errno(e):
 
 
 class Zeroconf(QuietLogger):
-
     """Implementation of Zeroconf Multicast DNS Service Discovery
 
     Supports registration, unregistration, queries and browsing.
     """
 
     def __init__(
-        self,
-        loop,
-        address_family = [netifaces.AF_INET,netifaces.AF_INET6],
-        iface=""
+            self,
+            loop,
+            address_family=[netifaces.AF_INET, netifaces.AF_INET6],
+            iface=""
     ):
         """Creates an instance of the Zeroconf class, establishing
         multicast communications, listening and reaping threads.
@@ -1619,13 +1600,13 @@ class Zeroconf(QuietLogger):
         self.futures = {}
 
         for af in address_family:
-            sock = new_socket(af,iface)
+            sock = new_socket(af, iface)
             if sock:
                 self.futures[af] = asyncio.Future()
                 listen = loop.create_datagram_endpoint(
-                    partial(MCListener,self, self.futures[af]),
+                    partial(MCListener, self, self.futures[af]),
                     sock=sock,
-                    )
+                )
                 xx = asyncio.ensure_future(listen)
 
         self.loop.create_task(self.synchronize())
@@ -1645,11 +1626,10 @@ class Zeroconf(QuietLogger):
         return self._GLOBAL_DONE
 
     async def synchronize(self):
-        loaf = [ x for x in self.futures]
+        loaf = [x for x in self.futures]
         for af in loaf:
             await self.futures[af]
             self.protocols[af] = self.futures[af].result()
-
 
     async def get_service_info(self, type_, name, timeout=3000):
         """Returns network's service information for a particular
@@ -1694,7 +1674,7 @@ class Zeroconf(QuietLogger):
         i = 0
         while i < 3:
             if now < next_time:
-                await asyncio.sleep((next_time - now)/1000.0)
+                await asyncio.sleep((next_time - now) / 1000.0)
                 now = current_time_millis()
                 continue
             out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
@@ -1730,7 +1710,7 @@ class Zeroconf(QuietLogger):
         i = 0
         while i < 3:
             if now < next_time:
-                await asyncio.sleep((next_time - now)/1000.0)
+                await asyncio.sleep((next_time - now) / 1000.0)
                 now = current_time_millis()
                 continue
             out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
@@ -1758,7 +1738,7 @@ class Zeroconf(QuietLogger):
             i = 0
             while i < 3:
                 if now < next_time:
-                    await asyncio.sleep((next_time - now)/1000.0)
+                    await asyncio.sleep((next_time - now) / 1000.0)
                     now = current_time_millis()
                     continue
                 out = DNSOutgoing(_FLAGS_QR_RESPONSE | _FLAGS_AA)
@@ -1810,7 +1790,7 @@ class Zeroconf(QuietLogger):
                 i = 0
 
             if now < next_time:
-                await asyncio.sleep((next_time - now)/1000.0)
+                await asyncio.sleep((next_time - now) / 1000.0)
                 now = current_time_millis()
                 continue
 
@@ -1834,7 +1814,6 @@ class Zeroconf(QuietLogger):
                 if question.answered_by(record) and not record.is_expired(now):
                     listener.update_record(self, now, record)
 
-
     def remove_listener(self, listener):
         """Removes a listener."""
         try:
@@ -1848,7 +1827,6 @@ class Zeroconf(QuietLogger):
         a record."""
         for listener in self.listeners:
             listener.update_record(self, now, rec)
-
 
     def handle_response(self, msg):
         """Deal with incoming response packets.  All answers
@@ -1943,7 +1921,7 @@ class Zeroconf(QuietLogger):
                                   out, len(packet), packet)
             return
         log.debug('Sending %r (%d bytes) as %r...', out, len(packet), packet)
-        for af,sp in self.protocols.items():
+        for af, sp in self.protocols.items():
             if addr:
                 addrfam = socket.getaddrinfo(addr, None)[0][0]
                 if addrfam != af:
@@ -1954,10 +1932,10 @@ class Zeroconf(QuietLogger):
             s, p = sp
             try:
                 if af == netifaces.AF_INET:
-                    s.sendto(packet,(addr or _MDNS_ADDR, port or _MDNS_PORT ))
+                    s.sendto(packet, (addr or _MDNS_ADDR, port or _MDNS_PORT))
                 else:
-                    s.sendto(packet, (addr or _MDNS6_ADDR, port or _MDNS_PORT ))
-            except Exception:   # TODO stop catching all Exceptions
+                    s.sendto(packet, (addr or _MDNS6_ADDR, port or _MDNS_PORT))
+            except Exception:  # TODO stop catching all Exceptions
                 # on send errors, log the exception and keep going
                 self.log_exception_warning()
 
@@ -1971,7 +1949,7 @@ class Zeroconf(QuietLogger):
             await self.unregister_all_services()
 
             # shutdown recv socket and thread
-            for t,proto in self.protocols.values():
+            for t, proto in self.protocols.values():
                 try:
                     proto.connection_lost(None)
                     proto.transport.close()


### PR DESCRIPTION
As discussed in [previous pull request](https://github.com/frawau/aiozeroconf/pull/3), the way interfaces were handled was prone to getting answers on only one interface.

This PR propose the following:
- having one socket sender per interface
- reworking the way MCListeners are initiated
- fixing the IPv6 part for getting extra info
- some light code cleanup here and there

I will have to make more tests with multiple interfaces scenarios, please wait a bit before integrating and/or test on your side!

Thx!