### PR TITLE
add option to find service types

### DIFF
--- a/aiozeroconf/__main__.py
+++ b/aiozeroconf/__main__.py
@@ -29,7 +29,7 @@ import sys
 import argparse
 import netifaces
 
-from aiozeroconf import ServiceBrowser, ServiceStateChange, Zeroconf
+from aiozeroconf import ServiceBrowser, ServiceStateChange, Zeroconf, ZeroconfServiceTypes
 
 
 def on_service_state_change(zc, service_type, name, state_change):
@@ -60,6 +60,11 @@ async def on_service_state_change_process(zc, service_type, name):
     print('\n')
 
 
+async def list_service(zc):
+    los = await ZeroconfServiceTypes.find(zc, timeout=1)
+    print("Services:\n{}".format('\n'.join(['\t{}'.format(s) for s in los])))
+
+
 async def do_close(zc):
     await zc.close()
 
@@ -71,6 +76,8 @@ parser.add_argument('-p', "--protocol", choices=['ipv4', 'ipv6', 'both'], defaul
                     help="What IP protocol to use.")
 parser.add_argument("-s", "--service", default="_http._tcp.local.",
                     help="The service to browse.")
+parser.add_argument("-f", "--find", action='store_true', default=False,
+                    help="Find services")
 parser.add_argument("-d", "--debug", action='store_true', default=False,
                     help="Set debug mode.")
 try:
@@ -93,9 +100,13 @@ if opts.debug:
 
 zc = Zeroconf(loop, proto, iface=opts.iface)
 print("\nBrowsing services, press Ctrl-C to exit...\n")
-browser = ServiceBrowser(zc, opts.service, handlers=[on_service_state_change])
+
 try:
-    loop.run_forever()
+    if opts.find:
+        loop.run_until_complete(list_service(zc))
+    else:
+        browser = ServiceBrowser(zc, opts.service, handlers=[on_service_state_change])
+        loop.run_forever()
 except KeyboardInterrupt:
     print("Unregistering...")
     loop.run_until_complete(do_close(zc))

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -1227,7 +1227,7 @@ class ServiceBrowser(object):
 class ServiceInfo(object):
     """Service information"""
 
-    def __init__(self, type_, name, address=None, address6=None, port=None, weight=0,
+    def __init__(self, type_, name, *, address=None, address6=None, port=None, weight=0,
                  priority=0, properties=None, server=None):
         """Create a service description.
 

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -1627,7 +1627,7 @@ def setup_inet6(interfaces: List[str]):
             indexes.append((interface, idx))
 
     if not indexes:
-        raise ValueError('No interface for IPv4')
+        raise ValueError('No interface for IPv6')
 
     addrinfo = socket.getaddrinfo(_MDNS6_ADDR, None)[0]
     group_bin = socket.inet_pton(addrinfo[0], addrinfo[4][0])

--- a/aiozeroconf/aiozeroconf.py
+++ b/aiozeroconf/aiozeroconf.py
@@ -424,6 +424,7 @@ class DNSRecord(DNSEntry):
     @abstractmethod
     def __eq__(self, other):
         """All records must implement this"""
+        raise NotImplementedError
 
     def suppressed_by(self, msg):
         """Returns true if any answer in a message can suffice for the
@@ -464,6 +465,7 @@ class DNSRecord(DNSEntry):
     @abstractmethod
     def write(self, out):
         """Write data out"""
+        raise NotImplementedError
 
     def to_string(self, other):
         """String representation with additional information"""


### PR DESCRIPTION
The ability to do a `python -m aiozeroconf` is very nice, and now adding an option to find services as well. Convenient for discovery and also testing!